### PR TITLE
Ensure blank cells are returned as 'nil' instead of being omitted

### DIFF
--- a/src/clj_excel/core.clj
+++ b/src/clj_excel/core.clj
@@ -178,12 +178,12 @@
   [wb] (map #(.getSheetAt wb %1) (range 0 (.getNumberOfSheets wb))))
 
 (defn rows
-  "Return rows from sheet as seq.  Simple seq cast via Iterable implementation."
-  [sheet] (seq sheet))
+  "Return rows from sheet as seq."
+  [sheet] (mapv #(.getRow sheet %) (range 0 (inc (.getLastRowNum sheet)))))
 
 (defn cells
-  "Return seq of cells from row.  Simpel seq cast via Iterable implementation." 
-  [row] (seq row))
+  "Return seq of cells from row."
+  [row] (if-not row [] (map #(.getCell row % Row/CREATE_NULL_AS_BLANK) (range 0 (.getLastCellNum row)))))
 
 (defn values
   "Return cells from sheet as seq."
@@ -192,7 +192,7 @@
 (defn lazy-sheet
   "Lazy seq of seq representing rows and cells."
   ([sheet] (lazy-sheet sheet cell-value))
-  ([sheet cell-fn] (map #(map cell-fn %1) sheet)))
+  ([sheet cell-fn] (map #(map cell-fn (cells %)) (rows sheet))))
 
 (defn sheet-names
   [wb]

--- a/test/clj_excel/test/core.clj
+++ b/test/clj_excel/test/core.clj
@@ -35,6 +35,14 @@
 ;; just numbers (doubles in poi); note: rows need not have equal length
 (def trivial-input {"one" [[1.0] [2.0 3.0] [4.0 5.0 6.0]]})
 
+(deftest gaps-parsed
+  (let [wb-with-gaps (wb-from-data {"one" [[1.0]]})
+        sheet (.getSheetAt wb-with-gaps 0)
+        _ (set-cell sheet 0 2 2.0)
+        _ (set-cell sheet 2 1 4.0)]
+    (is (= {"one" [[1.0 nil 2.0] [] [nil 4.0]]}
+           (lazy-workbook (save-load-cycle wb-with-gaps))))))
+
 (deftest roundtrip-trivial
   (is (valid-workbook-roundtrip? trivial-input :xssf))
   (is (valid-workbook-roundtrip? trivial-input :hssf)))


### PR DESCRIPTION
This is to fix an issue when reading a spreadsheet with blank values. The iterator behaviour from POI skips blank rows and cells.

Intend to read tabular data and just zipmap the header row with remaining but any rows containing blank cells ended up with mismatched data.
## Example

<table>
<tr>
<td>Col 1</td>
<td>Col 2</td>
</tr>
<tr>
<td>Row 1 Val 1</td>
<td>Row 1 Val 2</td>
</tr>
<tr>
<td></td>
<td>Row 2 Val 2</td>
</tr>
</table>


Would end up as 

```
[
{"Col 1" "Row 1 Val 1" "Col 2" "Row 1 Val 2" }
{"Col 1" "Row 1 Val 2" "Col 2" nil}
]
```

instead of 

```
[
{"Col 1" "Row 1 Val 1" "Col 2" "Row 1 Val 2" }
{"Col 1" nil "Col 2" "Row 1 Val 2"}
]
```
